### PR TITLE
Add support for cocoapods and use `.deplock` extension for Swift manifest dump file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ Supported Ecosystems
 - **pnpm**: https://pnpm.io/
 - **yarn**: https://yarnpkg.com/
 - **swift**: https://www.swift.org/documentation/package-manager/
+- **cocoapods**: https://cocoapods.org/
 
 
 Installation

--- a/cmd/cocoapods.go
+++ b/cmd/cocoapods.go
@@ -1,0 +1,44 @@
+/*
+
+Copyright (c) nexB Inc. and others. All rights reserved.
+ScanCode is a trademark of nexB Inc.
+SPDX-License-Identifier: Apache-2.0
+See http://www.apache.org/licenses/LICENSE-2.0 for the license text.
+See https://github.com/nexB/dependency-inspector for support or download.
+See https://aboutcode.org for more information about nexB OSS projects.
+
+*/
+
+package cmd
+
+import (
+	"github.com/nexB/dependency-inspector/internal"
+	"github.com/spf13/cobra"
+)
+
+func cocoapodsCmd() *cobra.Command {
+	lockFiles := []string{"Podfile.lock"}
+	lockGenCommand := []string{"pod", "install"}
+	forced := false
+
+	cocoapodsCmd := &cobra.Command{
+		Use:   "cocoapods [path]",
+		Short: "Generate lockfile for cocoapods project",
+		Long: `Create lockfile for cocoapods project if it doesn't exist in the specified [path].
+If no path is provided, the command defaults to the current directory.`,
+		Args: cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			internal.CreateLockFile(
+				lockFiles,
+				args,
+				lockGenCommand,
+				"",
+				forced,
+			)
+		},
+	}
+
+	cocoapodsCmd.Flags().BoolVarP(&forced, "force", "f", false, "Generate lockfile forcibly, ignoring existing lockfiles")
+
+	return cocoapodsCmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ var ecosystems = []func() *cobra.Command{
 	npmCmd,
 	yarnCmd,
 	swiftCmd,
+	cocoapodsCmd,
 }
 
 func NewRootCmd() *cobra.Command {

--- a/cmd/swift.go
+++ b/cmd/swift.go
@@ -17,18 +17,13 @@ import (
 )
 
 func swiftCmd() *cobra.Command {
-	lockFiles := [][]string{
-		{"Package.resolved", ".package.resolved"},
-		{"Package.swift.json"},
-	}
-	lockGenCommands := [][]string{
-		{"swift", "package", "resolve"},
-		{"swift", "package", "dump-package"},
-	}
-	commandOutput := []string{
-		"",
-		"Package.swift.json",
-	}
+	deplockSwiftManifestDumpFile := "Package.swift.deplock"
+	resolvedLockFiles := []string{"Package.resolved", ".package.resolved"}
+	deplockManifestDumpFiles := []string{deplockSwiftManifestDumpFile}
+
+	resolvedLockGenCommand := []string{"swift", "package", "resolve"}
+	deplockManifestDumpGenCommand := []string{"swift", "package", "dump-package"}
+
 	forced := false
 
 	swiftCmd := &cobra.Command{
@@ -41,15 +36,21 @@ If no path is provided, the command defaults to the current directory.`,
 
 		Run: func(cmd *cobra.Command, args []string) {
 
-			for i := range lockFiles {
-				internal.CreateLockFile(
-					lockFiles[i],
-					args,
-					lockGenCommands[i],
-					commandOutput[i],
-					forced,
-				)
-			}
+			internal.CreateLockFile(
+				resolvedLockFiles,
+				args,
+				resolvedLockGenCommand,
+				"",
+				forced,
+			)
+
+			internal.CreateLockFile(
+				deplockManifestDumpFiles,
+				args,
+				deplockManifestDumpGenCommand,
+				deplockSwiftManifestDumpFile,
+				forced,
+			)
 
 		},
 	}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -27,8 +27,8 @@ func CreateLockFile(lockFiles []string, cmdArgs []string, lockGenCmd []string, o
 
 	absPath, err := filepath.Abs(path)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: Failed to retrieve absolute path: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintln(os.Stderr, "Error: Failed to retrieve absolute path: ", err)
+		return
 	}
 
 	if !forced {
@@ -39,7 +39,6 @@ func CreateLockFile(lockFiles []string, cmdArgs []string, lockGenCmd []string, o
 				continue
 			}
 			return
-
 		}
 	}
 	genLock(lockGenCmd, absPath, outputFileName)


### PR DESCRIPTION
- Resolves: https://github.com/nexB/dependency-inspector/issues/10
- Store the Swift manifest JSON dump in the `Package.swift.deplock` file. We use the `.deplock` extension for file names when we don't have any naming convention in the native package manager.