### PR TITLE
Support lockfile generation for python project and drop `update-lockfile` mode for yarn

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,7 @@ Supported Ecosystems
 - **yarn**: https://yarnpkg.com/
 - **swift**: https://www.swift.org/documentation/package-manager/
 - **cocoapods**: https://cocoapods.org/
+- **pypi**: https://pypi.org/
 
 
 Installation

--- a/cmd/pypi.go
+++ b/cmd/pypi.go
@@ -1,0 +1,45 @@
+/*
+
+Copyright (c) nexB Inc. and others. All rights reserved.
+ScanCode is a trademark of nexB Inc.
+SPDX-License-Identifier: Apache-2.0
+See http://www.apache.org/licenses/LICENSE-2.0 for the license text.
+See https://github.com/nexB/dependency-inspector for support or download.
+See https://aboutcode.org for more information about nexB OSS projects.
+
+*/
+
+package cmd
+
+import (
+	"github.com/nexB/dependency-inspector/internal"
+	"github.com/spf13/cobra"
+)
+
+func pypiCmd() *cobra.Command {
+	pipFreezeFile := "requirements.deplock"
+	lockFiles := []string{"Pipfile.lock", pipFreezeFile}
+	lockGenCommand := []string{"pip", "freeze"}
+	forced := false
+
+	pypiCmd := &cobra.Command{
+		Use:   "pypi [path]",
+		Short: "Generate lockfile for Python project",
+		Long: `Create lockfile for Python project if it doesn't exist in the specified [path].
+If no path is provided, the command defaults to the current directory.`,
+		Args: cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			internal.CreateLockFile(
+				lockFiles,
+				args,
+				lockGenCommand,
+				pipFreezeFile,
+				forced,
+			)
+		},
+	}
+
+	pypiCmd.Flags().BoolVarP(&forced, "force", "f", false, "Generate lockfile forcibly, ignoring existing lockfiles")
+
+	return pypiCmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ var ecosystems = []func() *cobra.Command{
 	yarnCmd,
 	swiftCmd,
 	cocoapodsCmd,
+	pypiCmd,
 }
 
 func NewRootCmd() *cobra.Command {

--- a/cmd/yarn.go
+++ b/cmd/yarn.go
@@ -18,7 +18,7 @@ import (
 
 func yarnCmd() *cobra.Command {
 	lockFiles := []string{"yarn.lock"}
-	lockGenCommand := []string{"yarn", "install", "--mode", "update-lockfile"}
+	lockGenCommand := []string{"yarn", "install"}
 	forced := false
 
 	yarnCmd := &cobra.Command{


### PR DESCRIPTION
- Resolves: #8 
- Use yarn install to create yarn.lock file