### PR TITLE
Generate Python dependency relationships using pip inspect

### DIFF
--- a/cmd/pypi.go
+++ b/cmd/pypi.go
@@ -17,9 +17,9 @@ import (
 )
 
 func pypiCmd() *cobra.Command {
-	pipFreezeFile := "requirements.deplock"
-	lockFiles := []string{"Pipfile.lock", pipFreezeFile}
-	lockGenCommand := []string{"pip", "freeze"}
+	pipInspectFile := "pip-inspect.deplock"
+	lockFiles := []string{pipInspectFile}
+	lockGenCommand := []string{"pip", "inspect"}
 	forced := false
 
 	pypiCmd := &cobra.Command{
@@ -33,7 +33,7 @@ If no path is provided, the command defaults to the current directory.`,
 				lockFiles,
 				args,
 				lockGenCommand,
-				pipFreezeFile,
+				pipInspectFile,
 				forced,
 			)
 		},


### PR DESCRIPTION
`pip freeze` does not include the relationship between dependencies. Instead, use `pip inspect` to get the JSON report of the Python environment, which includes the dependency relationships, and store it in the `pip-inspect.deplock` file.